### PR TITLE
Changes package target type

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"regexp"

--- a/event_test.go
+++ b/event_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/goxtremio.go
+++ b/goxtremio.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"os"
@@ -10,10 +10,6 @@ import (
 var xms *xmsv3.XMS
 
 func init() {
-
-}
-
-func main() {
 
 }
 

--- a/initiator.go
+++ b/initiator.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/initiator_test.go
+++ b/initiator_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/initiatorgroup.go
+++ b/initiatorgroup.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/initiatorgroup_test.go
+++ b/initiatorgroup_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/initiatorgroupfolder.go
+++ b/initiatorgroupfolder.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/initiatorgroupfolder_test.go
+++ b/initiatorgroupfolder_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/iscsiportal.go
+++ b/iscsiportal.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/iscsiportal_test.go
+++ b/iscsiportal_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/lunmap.go
+++ b/lunmap.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/lunmap_test.go
+++ b/lunmap_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/volume.go
+++ b/volume.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/volume_test.go
+++ b/volume_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"

--- a/volumefolder.go
+++ b/volumefolder.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import xmsv3 "github.com/emccode/goxtremio/api/v3"
 

--- a/volumefolder_test.go
+++ b/volumefolder_test.go
@@ -1,4 +1,4 @@
-package main
+package goxtremio
 
 import (
 	"fmt"


### PR DESCRIPTION
This patch changes the package target type from an executable binary to
a package object. This was achieved by removing the main() function from
the goxtremio.go source file and also changing the package for all
source files previously in the "main" package to be in the "goxtremio"
package.