### PR TITLE
Logrus Support

### DIFF
--- a/api/v3/xms.go
+++ b/api/v3/xms.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	
+	log "github.com/Sirupsen/logrus"
 )
 
 type XMS struct {


### PR DESCRIPTION
This patch switches the GoXtremIO library from using the stdlib log package to using the Logrus logging package.